### PR TITLE
Set _WIN32_WINNT Macro

### DIFF
--- a/windows/ThreadCount-Win7.cpp
+++ b/windows/ThreadCount-Win7.cpp
@@ -3,6 +3,8 @@
 // GetLogicalProcessorInformationEx requires Win7 or later
 // based on https://msdn.microsoft.com/en-us/library/windows/desktop/dd405488(v=vs.85).aspx
 
+#define _WIN32_WINNT 0x0601
+
 #include <stdio.h>
 #include <intrin.h>
 #include <windows.h>


### PR DESCRIPTION
```GetLogicalProcessorInformationEx()``` has been introduced as of Windows 7.
Therefore, set ```_WIN32_WINNT``` macro to ```0x0601``` is required before including ```Windows.h``` and also compiler portability.