### PR TITLE
Use logical count for everything newer than dozer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ These self-contained code samples show you how to correctly detect physical and 
 ## Support and suggestions
 
 If you spot a bug, or would like to see the samples evolve in a particular way, file an issue and we'll take a look!
+
+## Further reading
+
+- Ken Mitchell (2017). [CPU Core Count Detection on Windows®](https://gpuopen.com/learn/cpu-core-count-detection-windows/). *GPUOpen*.
+- Ken Mitchell, Elliot Kim (2018). [AMD Ryzen™ CPU Optimization](https://gpuopen.com/wp-content/uploads/2018/05/gdc_2018_sponsored_optimizing_for_ryzen.pdf). Presented on GDC 2018.

--- a/windows/ThreadCount-Win7.cpp
+++ b/windows/ThreadCount-Win7.cpp
@@ -73,8 +73,10 @@ DWORD getDefaultThreadCount() {
 	char vendor[13];
 	getCpuidVendor(vendor);
 	if (0 == strcmp(vendor, "AuthenticAMD")) {
-		if (0x15 == getCpuidFamily()) {
-			// AMD "Bulldozer" family microarchitecture
+		if (0x15 <= getCpuidFamily()) {
+			// AMD "Bulldozer" family microarchitecture or newer
+			// Jaguar does not have SMT, and Zen SMT is no worse than Bulldozer
+			// MAINTAINER: remember to update if SMT ever gets bad!
 			count = logical;
 		}
 		else {
@@ -92,8 +94,8 @@ int main(int argc, char* argv[]) {
 
 	DWORD cores, logical;
 	getProcessorCount(cores, logical);
-	if ((0 == strcmp(vendor, "AuthenticAMD")) && (0x15 == getCpuidFamily())) {
-		// AMD "Bulldozer" family microarchitecture
+	if ((0 == strcmp(vendor, "AuthenticAMD")) && (0x15 <= getCpuidFamily())) {
+		// AMD "Bulldozer" family microarchitecture or newer
 		printf("Processor Module Count: %u\n", logical / 2);
 		printf("Processor Core Count: %u\n", logical);
 	}

--- a/windows/ThreadCount-WinXP.cpp
+++ b/windows/ThreadCount-WinXP.cpp
@@ -72,7 +72,9 @@ DWORD getDefaultThreadCount() {
 	getCpuidVendor(vendor);
 	if (0 == strcmp(vendor, "AuthenticAMD")) {
 		if (0x15 == getCpuidFamily()) {
-			// AMD "Bulldozer" family microarchitecture
+			// AMD "Bulldozer" family microarchitecture or newer
+			// Jaguar does not have SMT, and Zen SMT is no worse than Bulldozer
+			// MAINTAINER: remember to update if SMT ever gets bad!
 			count = logical;
 		}
 		else {
@@ -90,8 +92,8 @@ int main(int argc, char* argv[]) {
 
 	DWORD cores, logical;
 	getProcessorCount(cores, logical);
-	if ((0 == strcmp(vendor, "AuthenticAMD")) && (0x15 == getCpuidFamily())) {
-		// AMD "Bulldozer" family microarchitecture
+	if ((0 == strcmp(vendor, "AuthenticAMD")) && (0x15 <= getCpuidFamily())) {
+		// AMD "Bulldozer" family microarchitecture or newer
 		printf("Processor Module Count: %u\n", logical / 2);
 		printf("Processor Core Count: %u\n", logical);
 	}


### PR DESCRIPTION
It probably doesn't make sense to kill the whole core detection completely, but we can still make everything a bit better by not limiting ourselves to dozer only. After all, Ken Mitchell 2017 does state that SMT is useful most of the time.

Fixes #2. Should be more in the spirit of @ThomasTheGerman's suggestion.